### PR TITLE
Min error on gauge when all values were the same and 0

### DIFF
--- a/metrics.js
+++ b/metrics.js
@@ -139,7 +139,7 @@ function createGauge(data, container) {
         avg = 0;
         sum = 0;
     } else if (values.every(value => value === values[0])) {
-        min = values[0] - 1;
+        min = Math.min(0, values[0]);
         max = values[0] +1;
         sum = values.reduce((acc, num) => acc + num, 0);
         avg = parseFloat((sum / values.length).toFixed(2));


### PR DESCRIPTION
Made it so min value if all values are the same is either 0 or the value in the array, whichever is smaller, so no more -1)